### PR TITLE
Add schema examples preview feature

### DIFF
--- a/apps/web/src/components/SchemaDiagram.tsx
+++ b/apps/web/src/components/SchemaDiagram.tsx
@@ -529,8 +529,9 @@ export const SchemaDiagram = forwardRef<SchemaDiagramHandle, SchemaDiagramProps>
       const expanded = !!sn.expansion?.expanded
       const sections = sn.expansion?.sections || {}
       const rawView = (sn.extra?.rawView as boolean | undefined) ?? model.rawView
+      const showExamples = (sn.extra?.showExamples as boolean | undefined) ?? model.showExamples
 
-      model.initLayout({ x: sn.position.x, y: sn.position.y }, expanded, rawView ?? false, sections)
+      model.initLayout({ x: sn.position.x, y: sn.position.y }, expanded, rawView ?? false, sections, showExamples)
 
       return {
         ...n,

--- a/apps/web/src/components/SchemaNodeModel.ts
+++ b/apps/web/src/components/SchemaNodeModel.ts
@@ -11,8 +11,10 @@ export class SchemaNodeModel {
   position: Position
   expanded: boolean
   rawView: boolean
+  showExamples: boolean
   sections: Record<string, boolean>
   properties?: any[]
+  examplesProperties?: any[]
   edges: SchemaEdgeModel[]
   isMaximized: boolean
   snapshotChecked: boolean
@@ -20,6 +22,7 @@ export class SchemaNodeModel {
   // Dirtiness detection
   origExpanded: boolean
   origRawView: boolean
+  origShowExamples: boolean
   origPosition: Position
   origSections: Record<string, boolean>
 
@@ -28,6 +31,7 @@ export class SchemaNodeModel {
     position?: Position
     expanded?: boolean
     rawView?: boolean
+    showExamples?: boolean
     sections?: Record<string, boolean>
     isMaximized?: boolean
   }) {
@@ -36,6 +40,7 @@ export class SchemaNodeModel {
     this.position = params.position ? { x: params.position.x, y: params.position.y } : { x: 0, y: 0 }
     this.expanded = params.expanded ?? true
     this.rawView = params.rawView ?? false
+    this.showExamples = params.showExamples ?? false
     this.sections = params.sections || {}
     this.edges = []
     this.isMaximized = params.isMaximized ?? false
@@ -43,25 +48,40 @@ export class SchemaNodeModel {
     this.properties = params.entity.isSchema
       ? parseSchemaToProperties(params.entity.content)
       : parseJsonToProperties(params.entity.content)
+    
+    // Extract examples from schema if available
+    if (params.entity.isSchema && params.entity.content?.examples) {
+      const examples = params.entity.content.examples
+      if (Array.isArray(examples) && examples.length > 0) {
+        this.examplesProperties = examples.map((example: any, index: number) => ({
+          name: `Example ${index + 1}`,
+          type: 'object',
+          children: parseJsonToProperties(example, `example-${index}`)
+        }))
+      }
+    }
 
     // Dirtiness calculation assistance
     this.origExpanded = params.expanded ?? true
     this.origRawView = params.rawView ?? false
+    this.origShowExamples = params.showExamples ?? false
     this.origPosition = params.position ? { x: params.position.x, y: params.position.y } : { x: 0, y: 0 }
     this.origSections = params.sections || {}
     debug.node("constructor node {" + this.entity.id + "} constructor", this.position.x, this.position.y, "orig:", this.origPosition.x, this.origPosition.y)
   }
 
   // apply layout from diagram storage
-  initLayout(position: Position, expanded: boolean, rawView: boolean, sections: Record<string, boolean>) {
+  initLayout(position: Position, expanded: boolean, rawView: boolean, sections: Record<string, boolean>, showExamples?: boolean) {
     // clone to avoid shared references
     this.position = { x: position.x, y: position.y }
     this.expanded = expanded
     this.rawView = rawView
+    this.showExamples = showExamples ?? false
     this.sections = { ...sections }
     this.snapshotChecked = true
     this.origExpanded = expanded
     this.origRawView = rawView
+    this.origShowExamples = showExamples ?? false
     this.origPosition = { x: position.x, y: position.y }
     this.origSections = { ...sections }
     debug.node("initLayout node {" + this.entity.id + "} applyLayoutFromSnapshot", position.x, position.y, "orig:", this.origPosition.x, this.origPosition.y)
@@ -76,6 +96,7 @@ export class SchemaNodeModel {
 
   isDirty(): boolean {
     if (this.rawView !== this.origRawView) return true
+    if (this.showExamples !== this.origShowExamples) return true
     if (this.position.x !== this.origPosition.x || this.position.y !== this.origPosition.y) return true
     if (this.expanded !== this.origExpanded) return true
 
@@ -103,6 +124,7 @@ export class SchemaNodeModel {
   resetDirtyBaseline() {
     this.origExpanded = this.expanded
     this.origRawView = this.rawView
+    this.origShowExamples = this.showExamples
     this.origPosition = { x: this.position.x, y: this.position.y }
     this.origSections = { ...this.sections }
     debug.node("resetDirtyBaseline node {" + this.entity.id + "} resetDirtyBaseline", this.origRawView, this.origPosition.x, this.origPosition.y, this.origSections)
@@ -120,7 +142,7 @@ export class SchemaNodeModel {
         expanded: this.expanded,
         sections: this.sections,
       },
-      extra: { rawView: this.rawView },
+      extra: { rawView: this.rawView, showExamples: this.showExamples },
     }
   }
 }

--- a/examples/events/schemas/gts.x.commerce.orders.order.v1.0~.schema.json
+++ b/examples/events/schemas/gts.x.commerce.orders.order.v1.0~.schema.json
@@ -260,5 +260,78 @@
       },
       "required": ["firstName", "lastName", "addressLine1", "city", "state", "postalCode", "country"]
     }
-  }
+  },
+  "examples": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "orderNumber": "ORD-2024-001234",
+      "status": "confirmed",
+      "customerId": "660e8400-e29b-41d4-a716-446655440001",
+      "customerEmail": "john.doe@example.com",
+      "subtotal": 149.97,
+      "taxAmount": 14.50,
+      "discountAmount": 15.00,
+      "totalAmount": 159.47,
+      "currency": "USD",
+      "items": [
+        {
+          "id": "770e8400-e29b-41d4-a716-446655440010",
+          "productId": "880e8400-e29b-41d4-a716-446655440011",
+          "productName": "Wireless Mouse",
+          "productSku": "WM-2024-BLK",
+          "quantity": 2,
+          "unitPrice": 29.99,
+          "totalPrice": 59.98,
+          "discountAmount": 0,
+          "taxAmount": 5.80
+        },
+        {
+          "id": "770e8400-e29b-41d4-a716-446655440012",
+          "productId": "880e8400-e29b-41d4-a716-446655440013",
+          "productName": "USB-C Cable",
+          "productSku": "USBC-2M-WHT",
+          "quantity": 3,
+          "unitPrice": 19.99,
+          "totalPrice": 59.97,
+          "discountAmount": 5.00,
+          "taxAmount": 5.30,
+          "metadata": {
+            "length": "2m",
+            "color": "white"
+          }
+        }
+      ],
+      "shippingAddress": {
+        "id": "990e8400-e29b-41d4-a716-446655440020",
+        "firstName": "John",
+        "lastName": "Doe",
+        "addressLine1": "123 Main Street",
+        "addressLine2": "Apt 4B",
+        "city": "New York",
+        "state": "NY",
+        "postalCode": "10001",
+        "country": "US",
+        "phone": "+1-555-123-4567"
+      },
+      "billingAddress": {
+        "id": "990e8400-e29b-41d4-a716-446655440021",
+        "firstName": "John",
+        "lastName": "Doe",
+        "addressLine1": "123 Main Street",
+        "city": "New York",
+        "state": "NY",
+        "postalCode": "10001",
+        "country": "US",
+        "phone": "+1-555-123-4567"
+      },
+      "shippingMethod": "standard",
+      "shippingCost": 10.00,
+      "paymentMethod": "credit_card",
+      "paymentStatus": "completed",
+      "paymentReference": "ch_1234567890abcdef",
+      "tags": ["priority", "new-customer"],
+      "createdAt": "2024-01-15T10:30:00Z",
+      "updatedAt": "2024-01-15T10:35:00Z"
+    }
+  ]
 }

--- a/examples/events/schemas/gts.x.core.events.topic.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.topic.v1~.schema.json
@@ -71,5 +71,42 @@
     },
     "tags": { "type": "array", "items": { "type": "string" } }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "examples": [
+    {
+      "id": "gts://gts.x.core.events.topic.v1~x.core.commerce.orders.v1~",
+      "$schema": "gts://gts.x.core.events.topic.v1~",
+      "name": "Orders Topic",
+      "description": "Stream for all order-related events",
+      "retention": "P90D",
+      "ordering": "by-partition-key",
+      "partitions": 16,
+      "partitionKeyPath": "/payload/orderId",
+      "dedup": {
+        "strategy": "by-key",
+        "keyPaths": ["/id"]
+      },
+      "storage": {
+        "kind": "db",
+        "config": {
+          "table": "events_orders"
+        }
+      },
+      "tags": ["commerce", "orders"]
+    },
+    {
+      "id": "gts://gts.x.core.events.topic.v1~x.core.idp.contacts.v1~",
+      "$schema": "gts://gts.x.core.events.topic.v1~",
+      "name": "Contacts Topic",
+      "description": "Stream for contact lifecycle events",
+      "retention": "P365D",
+      "ordering": "global",
+      "dedup": {
+        "strategy": "time-window",
+        "window": "PT5M",
+        "keyPaths": ["/id", "/type"]
+      },
+      "tags": ["idp", "contacts"]
+    }
+  ]
 }

--- a/examples/events/schemas/gts.x.core.events.type.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~.schema.json
@@ -86,5 +86,44 @@
       "$comment": "The value is mandatory if subject is present"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "examples": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "type": "gts://gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1~",
+      "$schema": "gts://gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1~",
+      "tenantId": "770e8400-e29b-41d4-a716-446655440001",
+      "userId": "880e8400-e29b-41d4-a716-446655440002",
+      "source": "order-service/v1.2.3",
+      "occurredAt": "2024-01-15T10:30:00Z",
+      "sequenceNumber": 12345,
+      "subject": "order-123",
+      "subjectType": "gts://gts.x.commerce.orders.order.v1.0~",
+      "payload": {
+        "orderId": "order-123",
+        "customerId": "customer-456",
+        "totalAmount": 99.99,
+        "currency": "USD"
+      }
+    },
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440003",
+      "type": "gts://gts.x.core.events.type.v1~x.core.idp.contact_created.v1~",
+      "$schema": "gts://gts.x.core.events.type.v1~x.core.idp.contact_created.v1~",
+      "tenantId": "770e8400-e29b-41d4-a716-446655440001",
+      "clientId": "990e8400-e29b-41d4-a716-446655440004",
+      "source": "idp-service/v2.0.1",
+      "occurredAt": "2024-01-15T11:00:00Z",
+      "ingestedAt": "2024-01-15T11:00:01Z",
+      "sequenceNumber": 67890,
+      "previousSequenceNumber": 67889,
+      "subject": "contact-789",
+      "subjectType": "gts://gts.x.core.idp.contact.v1.0~",
+      "payload": {
+        "contactId": "contact-789",
+        "email": "new.user@example.com",
+        "name": "New User"
+      }
+    }
+  ]
 }

--- a/examples/events/schemas/gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1~.schema.json
@@ -29,5 +29,38 @@
         }
       }
     }
+  ],
+  "examples": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440100",
+      "type": "gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1.0~",
+      "$schema": "gts://gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1.0~",
+      "tenantId": "770e8400-e29b-41d4-a716-446655440001",
+      "userId": "880e8400-e29b-41d4-a716-446655440002",
+      "source": "order-service/v1.2.3",
+      "occurredAt": "2024-01-15T10:30:00Z",
+      "sequenceNumber": 12345,
+      "subject": "550e8400-e29b-41d4-a716-446655440000",
+      "subjectType": "gts://gts.x.commerce.orders.order.v1.0~",
+      "payload": {
+        "orderId": "550e8400-e29b-41d4-a716-446655440000",
+        "customerId": "660e8400-e29b-41d4-a716-446655440001",
+        "totalAmount": 159.47,
+        "items": [
+          {
+            "productId": "880e8400-e29b-41d4-a716-446655440011",
+            "productName": "Wireless Mouse",
+            "quantity": 2,
+            "unitPrice": 29.99
+          },
+          {
+            "productId": "880e8400-e29b-41d4-a716-446655440013",
+            "productName": "USB-C Cable",
+            "quantity": 3,
+            "unitPrice": 19.99
+          }
+        ]
+      }
+    }
   ]
 }

--- a/examples/events/schemas/gts.x.core.events.type.v1~x.core.idp.contact_created.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~x.core.idp.contact_created.v1~.schema.json
@@ -34,5 +34,27 @@
         "topicRef": { "const": "gts.x.core.events.topic.v1~x.core.idp.contacts.v1" }
       }
     }
+  ],
+  "examples": [
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440200",
+      "type": "gts.x.core.events.type.v1~x.core.idp.contact_created.v1.0~",
+      "$schema": "gts://gts.x.core.events.type.v1~x.core.idp.contact_created.v1.0~",
+      "tenantId": "770e8400-e29b-41d4-a716-446655440001",
+      "clientId": "990e8400-e29b-41d4-a716-446655440004",
+      "source": "idp-service/v2.0.1",
+      "occurredAt": "2024-01-15T11:00:00Z",
+      "ingestedAt": "2024-01-15T11:00:01Z",
+      "sequenceNumber": 67890,
+      "previousSequenceNumber": 67889,
+      "subject": "550e8400-e29b-41d4-a716-446655440000",
+      "subjectType": "gts://gts.x.core.idp.contact.v1.0~",
+      "payload": {
+        "userId": "550e8400-e29b-41d4-a716-446655440000",
+        "email": "john.doe@example.com",
+        "name": "John Doe",
+        "roles": ["user", "customer"]
+      }
+    }
   ]
 }

--- a/examples/events/schemas/gts.x.core.idp.contact.v1.0~.schema.json
+++ b/examples/events/schemas/gts.x.core.idp.contact.v1.0~.schema.json
@@ -12,5 +12,25 @@
         "additionalProperties": true,
         "description": "Custom properties that can be inherited by specialized contact"
     }
-  }
+  },
+  "examples": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "email": "john.doe@example.com",
+      "name": "John Doe",
+      "custom_properties": {
+        "company": "Acme Corp",
+        "role": "Developer"
+      }
+    },
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440001",
+      "email": "jane.smith@example.com",
+      "name": "Jane Smith",
+      "custom_properties": {
+        "department": "Marketing",
+        "level": "Senior"
+      }
+    }
+  ]
 }

--- a/examples/events/schemas/gts.x.core.idp.contact.v1.0~x.core.idp.billing_contact.v1.0~.schema.json
+++ b/examples/events/schemas/gts.x.core.idp.contact.v1.0~x.core.idp.billing_contact.v1.0~.schema.json
@@ -20,5 +20,19 @@
         }
       }
     }
+  ],
+  "examples": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "email": "billing@example.com",
+      "name": "John Doe - Billing",
+      "custom_properties": {
+        "phone_number": "+1-555-123-4567",
+        "address": "123 Main Street, New York, NY 10001",
+        "currency": "USD",
+        "billing_enabled": true,
+        "payment_terms": "net30"
+      }
+    }
   ]
 }


### PR DESCRIPTION
- Add showExamples state to SchemaNodeModel
- Add toggle button (FileJson icon) to switch between schema and examples
- Reuse parseJsonToProperties for rendering examples as objects
- Add conditional rendering in SchemaNodeView (normal and maximized)
- Update layout serialization to persist showExamples state
- Add examples to all 7 schemas in examples/events/schemas

Closes #40

<img width="494" height="595" alt="image" src="https://github.com/user-attachments/assets/87447b8d-1170-46da-8c2a-bb77ad6dd39f" />
